### PR TITLE
Implement Display + Error for SanError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ pub enum SanError {
     RegexExhausted(String),
 }
 
+impl std::error::Error for SanError {}
+
 pub type Result<T> = std::result::Result<T, SanError>;
 
 /**


### PR DESCRIPTION
Side effect of this PR is my rust-fmt reformatted it, but it shouldn't affect the code.

SanError can be error propagated now via `?`.